### PR TITLE
feat: add SSL/TLS support for secure MySQL sync using preferred mode …

### DIFF
--- a/app/src/main/java/org/css_apps_m3/password_manager/data/SqlSyncConfig.kt
+++ b/app/src/main/java/org/css_apps_m3/password_manager/data/SqlSyncConfig.kt
@@ -18,7 +18,7 @@ enum class DbType(
         displayName  = "MySQL / MariaDB",
         defaultPort  = 3306,
         jdbcDriver   = "com.mysql.jdbc.Driver",
-        urlTemplate  = "jdbc:mysql://{host}:{port}/{database}?useSSL=false&allowPublicKeyRetrieval=true&connectTimeout=10000&socketTimeout=15000"
+        urlTemplate  = "jdbc:mysql://{host}:{port}/{database}?useSSL=true&sslMode=PREFERRED&allowPublicKeyRetrieval=true&connectTimeout=10000&socketTimeout=15000"
     ),
     SQLITE(
         displayName  = "SQLite (local .db file)",


### PR DESCRIPTION
### Descripcion / Description
Added SSL/TLS support parameters  (`useSSL=true&sslMode=PREFERRED`) to the MySQL connection string in `SqlSyncConfig.kt`.

**Why?** 
Cloud database providers (like TiDB Cloud) strictly prohibit insecure transport. Using `PREFERRED` ensures that the app can connect securely to cloud databases while maintaining backward compatibility for users running local MySQL instances without SSL.

**¡Un saludo desde México!**
Hola, Kartoffelspalt. Soy un desarrollador mexicano que descubrió tu excelente aplicación en F-Droid. Al intentar conectarla a mi base de datos en la nube (TiDB Cloud), me topé con el bloqueo de transporte inseguro. Me metí a revisar tu código en Kotlin, encontré la configuración de conexión y decidí implementar esta mejora usando el modo preferred para que la app sea más segura en internet abierto sin romperle la conexión local a nadie.

¡Espero que te sirva el aporte para las próximas versiones de F-Droid! Que siga creciendo el Open Source.